### PR TITLE
Fixed redis key mismatch that was causing registered servers to be improperly annihilated

### DIFF
--- a/metroplex.js
+++ b/metroplex.js
@@ -252,7 +252,7 @@ Metroplex.readable('sparks', function sparks(args, fn) {
 Metroplex.readable('setInterval', function setIntervals() {
   if (this.timer) clearInterval(this.timer);
 
-  var alive = this.namespace + this.address +':alive'
+  var alive = this.namespace + this.address
     , redis = this.redis
     , metroplex = this;
 


### PR DESCRIPTION
Looks like it was using the :alive suffix in some cases but not all cases? I might be totally off base but this seems to correct my issue! Let me know your thoughts

Thanks,
Andy