### PR TITLE
Assume that `::` is equivalent to `0.0.0.0`

### DIFF
--- a/metroplex.js
+++ b/metroplex.js
@@ -74,7 +74,7 @@ Metroplex.readable('parse', function parse(server) {
   //
   // Seriously, 0.0.0.0 is basically localhost. Get the correct address for it.
   //
-  if (address.address === '0.0.0.0') {
+  if (address.address === '0.0.0.0' || address.address === '::') {
     address.address = ip.address();
   }
 


### PR DESCRIPTION
In node 0.12 the HTTP server address defaults to `::` when the `hostname` argument of the `server.listen` method is undefined.

With this patch `::` is treated the same way we treat `0.0.0.0`.

My only concern is that `ip.address()` returns an IPv4 address, but we don't handle IPv6 addresses correctly so that should be another issue.

