### PR TITLE
Ditch leverage and redis in favor of ioredis

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ this plugin:
 - *redis*: Metroplex is currently using Redis as its default back-end for storing
   the state of the connections. If you do not supply us with a pre-defined Redis
   client (or authorized) we will create a Redis client which only connects to
-  localhost and Redis's default port number.
+  localhost and Redis's default port number. When provided this must be an
+  [`ioredis`](https://github.com/luin/ioredis) client.
 - *namespace*: As the databases are usually shared with other programs it's good
   to prefix all the data that you store, in Metroplex we prefix every key with
   the set namespace. The default namespace is `metroplex`.

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "eventemitter3": "1.1.x",
     "fusing": "1.0.x",
     "ip": "0.3.x",
-    "leverage": "0.1.x",
-    "redis": "0.12.x"
+    "ioredis": "1.5.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
     "mocha": "2.2.x",
     "omega-supreme": "0.0.x",
     "pre-commit": "1.0.x",
-    "primus": "3.0.x",
+    "primus": "3.1.x",
     "istanbul": "0.3.x",
     "ws": "0.7.x"
   },
   "dependencies": {
-    "async": "1.0.x",
+    "async": "1.3.x",
     "eventemitter3": "1.1.x",
     "fusing": "1.0.x",
     "ip": "0.3.x",

--- a/redis/annihilate.lua
+++ b/redis/annihilate.lua
@@ -6,7 +6,7 @@ local address = assert(KEYS[1], 'The server address is missing')
 
 --
 -- Get all the sparks for our given address so we can nuke them from our "global"
--- spark registry>
+-- spark registry.
 --
 local sparks = redis.call('SMEMBERS', namespace .. address ..':sparks')
 
@@ -20,7 +20,7 @@ end
 
 --
 -- Delete all left over references to this server address which are:
--- 
+--
 -- 1. Our dedicated sparks set
 -- 2. Our server in the servers list
 -- 3. The keep alive server update

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,7 +1,7 @@
 describe('plugin', function () {
   'use strict';
 
-  var redis = require('redis').createClient()
+  var redis = new require('ioredis')()
     , assume = require('assume')
     , Primus = require('primus')
     , metroplex = require('../');


### PR DESCRIPTION
When comparing [`ioredis`](https://github.com/luin/ioredis) and [`node_redis`](https://github.com/mranney/node_redis), I think that [`ioredis`](https://github.com/luin/ioredis) is better under every aspect. It is well maintained and has sane error handling.
It also has a nice feature to define custom commands form [lua scripts](https://github.com/luin/ioredis#lua-scripting) and I think that this feature is particularly useful to make this module easier to maintain.

This patch removes the `leverage` and `redis` dependencies in favor of `ioredis`. This is a breaking change because the optional redis client that can be passed to this module, must be an `ioredis` client.